### PR TITLE
Use API_BASE_URL env var

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=https://api.pinga.etc.br

--- a/client/src/app/checkout/page.tsx
+++ b/client/src/app/checkout/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { loadStripe } from "@stripe/stripe-js";
 import { useCart } from "@/contexts/CartContext";
 import Image from "next/image";
+import { API_BASE_URL } from "@/utils/api";
 
 const stripePromise = loadStripe(
   "pk_live_51R6aKTGdQrTu9hK3LggAl4OGzSvzEhtFneb4PC3uJNCBCeD9TxNUBTWxlnxeHAwOGXCO9wyxcYT7jatAKIEi7aIV0021K0WMml"
@@ -85,7 +86,7 @@ export default function CheckoutPage() {
         successUrl: `${origin}/sucesso?session_id={CHECKOUT_SESSION_ID}`,
         cancelUrl: `${origin}/`,
       };
-      const res = await fetch("https://api.pinga.etc.br/api/checkout", {
+      const res = await fetch(`${API_BASE_URL}/api/checkout`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),

--- a/client/src/app/produtos/[slug]/page.tsx
+++ b/client/src/app/produtos/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { FiShoppingCart } from "react-icons/fi"; // Certifique-se que react-icon
 import { useCart } from "@/contexts/CartContext";
 import ProductCard from "@/components/ProductCard";
 import { slugify } from "@/utils/slugify";
+import { API_BASE_URL } from "@/utils/api";
 
 interface Product {
   _id: string;
@@ -47,7 +48,7 @@ export default function ProductPage({ params }: { params: { slug: string } }) {
   ] = useState<ShippingOption | null>(null);
 
   useEffect(() => {
-    fetch("https://api.pinga.etc.br/api/produtos")
+    fetch(`${API_BASE_URL}/api/produtos`)
       .then((res) => {
         if (!res.ok) throw new Error(`Falha ao buscar produtos: ${res.status}`);
         return res.json();
@@ -135,7 +136,7 @@ export default function ProductPage({ params }: { params: { slug: string } }) {
         return;
       }
 
-      const url = `https://api.pinga.etc.br?cepDestino=${zip}&peso=${pesoTotalCalculado}&valor=${valorTotalDeclarado}`;
+      const url = `${API_BASE_URL}/api/frete?cepDestino=${zip}&peso=${pesoTotalCalculado}&valor=${valorTotalDeclarado}`;
       console.log("FRONTEND: URL da requisição de frete:", url);
 
       const res = await fetch(url);

--- a/client/src/components/ProductsClientComponent.tsx
+++ b/client/src/components/ProductsClientComponent.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import ProductCard from "@/components/ProductCard";
+import { API_BASE_URL } from "@/utils/api";
 
 interface FetchedProduct {
   _id: string;
@@ -25,7 +26,7 @@ export default function ProductsClientComponent() {
 
   useEffect(() => {
     setLoading(true);
-    fetch("https://api.pinga.etc.br/api/produtos")
+    fetch(`${API_BASE_URL}/api/produtos`)
       .then((res) => {
         if (!res.ok) throw new Error(`Status ${res.status}`);
         return res.json();

--- a/client/src/components/ProductsSection.tsx
+++ b/client/src/components/ProductsSection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import ProductCard from "@/components/ProductCard";
+import { API_BASE_URL } from "@/utils/api";
 
 interface Product {
   _id: string;
@@ -17,7 +18,7 @@ export default function ProductsSection() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch("https://api.pinga.etc.br/api/produtos")
+    fetch(`${API_BASE_URL}/api/produtos`)
       .then((res) => {
         if (!res.ok) throw new Error(`Status ${res.status}`);
         return res.json();

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'https://api.pinga.etc.br';


### PR DESCRIPTION
## Summary
- centralize API base URL in a new util
- add `.env.example` with API base variable
- update fetch calls to use the environment variable
- update shipping URL with `/api/frete`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4cbc18f0832e8435ff50ed9f2760